### PR TITLE
Refactor FIFO/pipe implementations and fix sys_fcntl flags handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ version = "0.1.0"
 dependencies = [
  "axerrno",
  "axfs_vfs",
+ "axio",
  "log",
  "ringbuffer",
  "ruxhal",

--- a/api/ruxos_posix_api/src/imp/fd_ops.rs
+++ b/api/ruxos_posix_api/src/imp/fd_ops.rs
@@ -239,8 +239,11 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> c_int {
             }
             ctypes::F_SETFL => {
                 // Set the file status flags to the value specified by `arg`
-                get_file_like(fd)?
-                    .set_flags(OpenFlags::from_bits_truncate(arg as _).status_flags())?;
+                let f = get_file_like(fd)?;
+                let old_access_flags = f.flags() & OpenFlags::O_ACCMODE;
+                f.set_flags(
+                    old_access_flags | OpenFlags::from_bits_truncate(arg as _).status_flags(),
+                )?;
                 Ok(0)
             }
             ctypes::F_GETFL => {

--- a/api/ruxos_posix_api/src/imp/fs.rs
+++ b/api/ruxos_posix_api/src/imp/fs.rs
@@ -432,9 +432,20 @@ pub fn sys_mknodat(
         let file_type = match mode & ctypes::S_IFMT {
             ctypes::S_IFREG => FileType::File,
             ctypes::S_IFIFO => FileType::Fifo,
-            _ => return Err(LinuxError::EAFNOSUPPORT),
+            _ => todo!(),
         };
-        ruxfs::api::create_node(&path, file_type)?;
+
+        match file_type {
+            FileType::File => fops::create_file(&path)?,
+            FileType::Fifo => {
+                if path.starts_with("/tmp/") {
+                    fops::create_fifo(&path)?;
+                } else {
+                    todo!();
+                }
+            }
+            _ => todo!(),
+        }
         Ok(0)
     })
 }

--- a/api/ruxos_posix_api/src/imp/io_mpx/epoll.rs
+++ b/api/ruxos_posix_api/src/imp/io_mpx/epoll.rs
@@ -160,6 +160,10 @@ impl FileLike for EpollInstance {
     fn set_flags(&self, _flags: ruxfs::OpenFlags) -> LinuxResult {
         Ok(())
     }
+
+    fn flags(&self) -> OpenFlags {
+        OpenFlags::O_RDWR
+    }
 }
 
 /// Creates a new epoll instance.

--- a/api/ruxos_posix_api/src/imp/net.rs
+++ b/api/ruxos_posix_api/src/imp/net.rs
@@ -316,6 +316,19 @@ impl FileLike for Socket {
         }
         Ok(())
     }
+
+    fn flags(&self) -> OpenFlags {
+        let nonblock = match self {
+            Socket::Udp(udpsocket) => udpsocket.lock().is_nonblocking(),
+            Socket::Tcp(tcpsocket) => tcpsocket.lock().is_nonblocking(),
+            Socket::Unix(unixsocket) => unixsocket.lock().is_nonblocking(),
+        };
+        if nonblock {
+            OpenFlags::O_NONBLOCK | OpenFlags::O_RDWR
+        } else {
+            OpenFlags::O_RDWR
+        }
+    }
 }
 
 impl From<SocketAddrV4> for ctypes::sockaddr_in {

--- a/api/ruxos_posix_api/src/imp/pipe.rs
+++ b/api/ruxos_posix_api/src/imp/pipe.rs
@@ -7,215 +7,39 @@
  *   See the Mulan PSL v2 for more details.
  */
 
-use alloc::sync::{Arc, Weak};
 use core::ffi::c_int;
-use ringbuffer::RingBuffer;
-use ruxfs::AbsPath;
+use ruxfs::fifo;
 
-use axerrno::{LinuxError, LinuxResult};
-use axio::PollState;
-use axsync::Mutex;
-use ruxfdtable::{FileLike, OpenFlags, RuxStat};
+use axerrno::LinuxError;
+use ruxfdtable::OpenFlags;
 
-use crate::{ctypes, sys_fcntl};
-use ruxtask::fs::{add_file_like, close_file_like};
-
-pub struct Pipe {
-    readable: bool,
-    buffer: Arc<Mutex<RingBuffer>>,
-    // to find the write end when the read end is closed
-    _write_end_closed: Option<Weak<Mutex<RingBuffer>>>,
-}
-
-impl Pipe {
-    pub fn new() -> (Pipe, Pipe) {
-        let buffer = Arc::new(Mutex::new(RingBuffer::new(ruxconfig::PIPE_BUFFER_SIZE)));
-        let read_end = Pipe {
-            readable: true,
-            buffer: buffer.clone(),
-            _write_end_closed: None,
-        };
-        let write_end = Pipe {
-            readable: false,
-            buffer: buffer.clone(),
-            _write_end_closed: Some(Arc::downgrade(&buffer)),
-        };
-        (read_end, write_end)
-    }
-
-    pub const fn readable(&self) -> bool {
-        self.readable
-    }
-
-    pub const fn writable(&self) -> bool {
-        !self.readable
-    }
-
-    pub fn write_end_close(&self) -> bool {
-        let write_end_count = Arc::weak_count(&self.buffer);
-        write_end_count == 0
-    }
-}
-
-impl FileLike for Pipe {
-    fn path(&self) -> AbsPath {
-        AbsPath::new("/dev/pipe")
-    }
-
-    fn read(&self, buf: &mut [u8]) -> LinuxResult<usize> {
-        if !self.readable() {
-            return Err(LinuxError::EPERM);
-        }
-        let mut read_size = 0usize;
-        let max_len = buf.len();
-        let mut ring_buffer = self.buffer.lock();
-        // First, check if there is data in the read end.
-        // This loop is only runs when the write end is open
-        // and there is no data available
-        loop {
-            let loop_read = ring_buffer.available_read();
-            // If there is no data
-            if loop_read == 0 {
-                if self.write_end_close() {
-                    // write end is closed, read 0 bytes.
-                    return Ok(0);
-                } else {
-                    // write end is open
-                    drop(ring_buffer);
-                    // Data not ready, wait for write end
-                    crate::sys_sched_yield(); // TODO: use synconize primitive
-                    ring_buffer = self.buffer.lock();
-                }
-            } else {
-                break;
-            }
-        }
-        // read data
-        let loop_read = ring_buffer.available_read();
-        for _ in 0..loop_read {
-            if read_size == max_len {
-                return Ok(read_size);
-            }
-            debug_assert!(!ring_buffer.is_empty());
-            buf[read_size] = ring_buffer.dequeue().unwrap();
-            read_size += 1;
-        }
-        Ok(read_size)
-    }
-
-    fn write(&self, buf: &[u8]) -> LinuxResult<usize> {
-        if !self.writable() {
-            return Err(LinuxError::EPERM);
-        }
-        let mut write_size = 0usize;
-        let max_len = buf.len();
-        loop {
-            let mut ring_buffer = self.buffer.lock();
-            let loop_write = ring_buffer.available_write();
-            if loop_write == 0 {
-                drop(ring_buffer);
-                // Buffer is full, wait for read end to consume
-                crate::sys_sched_yield(); // TODO: use synconize primitive
-                continue;
-            }
-            for _ in 0..loop_write {
-                if write_size == max_len {
-                    return Ok(write_size);
-                }
-                debug_assert!(!ring_buffer.is_full());
-                ring_buffer.enqueue(buf[write_size]);
-                write_size += 1;
-            }
-        }
-    }
-
-    fn flush(&self) -> LinuxResult {
-        Ok(())
-    }
-
-    fn stat(&self) -> LinuxResult<RuxStat> {
-        let st_mode = 0o10000 | 0o600u32; // S_IFIFO | rw-------
-        Ok(RuxStat::from(ctypes::stat {
-            st_ino: 1,
-            st_nlink: 1,
-            st_mode,
-            st_uid: 1000,
-            st_gid: 1000,
-            st_blksize: 4096,
-            ..Default::default()
-        }))
-    }
-
-    fn into_any(self: Arc<Self>) -> Arc<dyn core::any::Any + Send + Sync> {
-        self
-    }
-
-    fn poll(&self) -> LinuxResult<PollState> {
-        let buf = self.buffer.lock();
-        Ok(PollState {
-            readable: self.readable() && buf.available_read() > 0,
-            writable: self.writable() && buf.available_write() > 0,
-            pollhup: self.write_end_close(),
-        })
-    }
-
-    fn set_flags(&self, _flags: OpenFlags) -> LinuxResult {
-        Ok(())
-    }
-}
+use ruxtask::fs::add_file_like;
 
 /// Create a pipe
 ///
 /// Return 0 if succeed
 pub fn sys_pipe(fds: &mut [c_int]) -> c_int {
-    debug!("sys_pipe <= {:#x}", fds.as_ptr() as usize);
-    syscall_body!(sys_pipe, {
-        if fds.len() != 2 {
-            return Err(LinuxError::EFAULT);
-        }
-
-        let (read_end, write_end) = Pipe::new();
-        let read_fd = add_file_like(Arc::new(read_end), OpenFlags::empty())?;
-        let write_fd =
-            add_file_like(Arc::new(write_end), OpenFlags::empty()).inspect_err(|_| {
-                close_file_like(read_fd).ok();
-            })?;
-
-        fds[0] = read_fd as c_int;
-        fds[1] = write_fd as c_int;
-
-        debug!("[sys_pipe] create pipe with read fd {read_fd} and write fd {write_fd}");
-        Ok(0)
-    })
+    sys_pipe2(fds, 0)
 }
 
 /// `pipe2` syscall, used by AARCH64
 ///
 /// Return 0 on success
 pub fn sys_pipe2(fds: &mut [c_int], flag: c_int) -> c_int {
-    debug!(
-        "sys_pipe2 <= fds: {:#x}, flag: {}",
-        fds.as_ptr() as usize,
-        flag
-    );
-    let ret = sys_pipe(fds);
-    if ret < 0 {
-        return ret;
-    }
     syscall_body!(sys_pipe2, {
-        if (flag as u32 & !(ctypes::O_CLOEXEC | ctypes::O_NONBLOCK)) != 0 {
-            return Err(LinuxError::EINVAL);
-        }
-
-        if (flag as u32 & ctypes::O_CLOEXEC) != 0 {
-            sys_fcntl(fds[0], ctypes::F_SETFD as _, ctypes::FD_CLOEXEC as _);
-            sys_fcntl(fds[1], ctypes::F_SETFD as _, ctypes::FD_CLOEXEC as _);
-        }
-
-        if (flag as u32 & ctypes::O_NONBLOCK) != 0 {
-            sys_fcntl(fds[0], ctypes::F_SETFL as _, ctypes::O_NONBLOCK as _);
-            sys_fcntl(fds[1], ctypes::F_SETFL as _, ctypes::O_NONBLOCK as _);
-        }
+        let flags = OpenFlags::from_bits(flag).ok_or(LinuxError::EINVAL)?;
+        debug!(
+            "sys_pipe2 <= fds: {:#x}, flag: {:?}",
+            fds.as_ptr() as usize,
+            flags
+        );
+        let (reader, writer) = fifo::new_pipe_pair(flags);
+        fds[0] = add_file_like(reader, flags)?;
+        fds[1] = add_file_like(writer, flags)?;
+        debug!(
+            "[sys_pipe] create pipe with read fd {} and write fd {}",
+            fds[0], fds[1]
+        );
         Ok(0)
     })
 }

--- a/api/ruxos_posix_api/src/imp/stdio.rs
+++ b/api/ruxos_posix_api/src/imp/stdio.rs
@@ -129,7 +129,7 @@ impl ruxfdtable::FileLike for Stdin {
     }
 
     fn flags(&self) -> OpenFlags {
-        let mut flags = OpenFlags::empty();
+        let mut flags = OpenFlags::O_RDONLY;
         if self.nonblocking.load(Ordering::Acquire) {
             flags |= OpenFlags::O_NONBLOCK;
         }
@@ -183,5 +183,9 @@ impl ruxfdtable::FileLike for Stdout {
 
     fn set_flags(&self, _flags: OpenFlags) -> LinuxResult {
         Ok(())
+    }
+
+    fn flags(&self) -> OpenFlags {
+        OpenFlags::O_WRONLY
     }
 }

--- a/api/ruxos_posix_api/src/imp/task.rs
+++ b/api/ruxos_posix_api/src/imp/task.rs
@@ -31,6 +31,17 @@ pub fn sys_sched_yield() -> c_int {
     0
 }
 
+#[cfg(feature = "fd")]
+struct SchedYieldIfImpl;
+
+#[cfg(feature = "fd")]
+#[crate_interface::impl_interface]
+impl ruxfs::fifo::SchedYieldIf for SchedYieldIfImpl {
+    fn yield_now() {
+        sys_sched_yield();
+    }
+}
+
 /// Get current thread ID.
 pub fn sys_gettid() -> c_int {
     syscall_body!(sys_gettid,

--- a/crates/axfs_ramfs/Cargo.toml
+++ b/crates/axfs_ramfs/Cargo.toml
@@ -16,3 +16,4 @@ log = { workspace = true }
 axerrno = { path = "../axerrno" }
 ruxhal = { path = "../../modules/ruxhal" }
 ringbuffer = { path = "../ringbuffer" }
+axio = { path = "../axio" }

--- a/crates/axfs_ramfs/src/fifo.rs
+++ b/crates/axfs_ramfs/src/fifo.rs
@@ -1,145 +1,143 @@
-use alloc::sync::Arc;
-use axerrno::{LinuxError, LinuxResult};
-use axfs_vfs::VfsNodeRef;
-use axfs_vfs::{impl_vfs_non_dir_default, VfsNodeAttr, VfsNodeOps, VfsResult};
-use core::sync::atomic::{AtomicUsize, Ordering};
-use log::debug;
-use ringbuffer::RingBuffer;
-use spin::Mutex;
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
 
-/// A simple FIFO implementation.
-pub struct Fifo {
-    buffer: Arc<Mutex<RingBuffer>>,
+use alloc::sync::Arc;
+use axerrno::AxError;
+use axfs_vfs::{impl_vfs_non_dir_default, VfsNodeAttr, VfsNodeOps, VfsResult};
+use axfs_vfs::{VfsNodePerm, VfsNodeType};
+use axio::PollState;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use ringbuffer::RingBuffer;
+use spin::mutex::Mutex;
+
+/// Default size of fifo
+const FIFO_SIZE: usize = 65536;
+
+/// FIFO (named pipe) node implementation for inter-process communication
+///
+/// Provides synchronized read/write operations through a fixed-size ring buffer,
+/// with atomic reference counting for concurrent access management.
+pub struct FifoNode {
+    /// VFS node attributes
+    attr: VfsNodeAttr,
+    /// Thread-safe ring buffer with mutual exclusion lock
+    buffer: Mutex<RingBuffer>,
+    /// Active readers counter (atomic for lock-free access)
     readers: AtomicUsize,
+    /// Active writers counter (atomic for lock-free access)
     writers: AtomicUsize,
 }
 
-impl Fifo {
-    // create a new fifo
-    pub fn new() -> Self {
+impl FifoNode {
+    /// create a new fifo
+    pub fn new(ino: u64) -> Self {
         Self {
-            buffer: Arc::new(Mutex::new(RingBuffer::new(1024))),
+            attr: VfsNodeAttr::new(ino, VfsNodePerm::default_fifo(), VfsNodeType::Fifo, 0, 0),
+            buffer: Mutex::new(RingBuffer::new(FIFO_SIZE)),
             readers: AtomicUsize::new(0),
             writers: AtomicUsize::new(0),
         }
     }
 
-    // read data from fifo
-    pub fn read(&self, buf: &mut [u8]) -> LinuxResult<usize> {
-        debug!("read data from fifo");
-        loop {
-            let mut rb = self.buffer.lock();
-            if rb.available_read() == 0 {
-                if self.writers.load(Ordering::SeqCst) == 0 {
-                    // when there is no writer and no data in the buffer, return EOF
-                    return Ok(0);
-                } else {
-                    drop(rb);
-                    sched_yield();
-                    continue;
-                }
-            }
-            // call the read() method of the ring buffer to copy the data to buf
-            let bytes_read = rb.read(buf);
-            return Ok(bytes_read);
-        }
+    /// Creates an interconnected pair of FIFO nodes for pipe communication
+    ///
+    /// Returns two `Arc` references sharing the same underlying buffer and counters,
+    /// typically used for creating pipe reader/writer endpoints.
+    pub fn new_pair() -> (Arc<Self>, Arc<Self>) {
+        let node = Arc::new(Self {
+            attr: VfsNodeAttr::new(1, VfsNodePerm::default_fifo(), VfsNodeType::Fifo, 0, 0),
+            buffer: Mutex::new(RingBuffer::new(FIFO_SIZE)),
+            readers: AtomicUsize::new(1),
+            writers: AtomicUsize::new(1),
+        });
+        (node.clone(), node)
     }
 
-    // write data to fifo
-    pub fn write(&self, buf: &[u8]) -> LinuxResult<usize> {
-        debug!("write data to fifo");
-        loop {
-            let mut rb = self.buffer.lock();
-            if self.readers.load(Ordering::SeqCst) == 0 {
-                // when there is no reader, return EPIPE
-                return Err(LinuxError::EPIPE);
-            }
-            let bytes_written = rb.write(buf);
-            if bytes_written > 0 {
-                return Ok(bytes_written);
-            }
-            drop(rb);
-            sched_yield();
-        }
+    /// Returns current number of active readers
+    pub fn readers(&self) -> usize {
+        self.readers.load(Ordering::Acquire)
     }
-}
 
-/// A node representing a FIFO.
-pub struct FifoNode {
-    ino: u64,
-    fifo: Fifo,
-}
+    /// Registers a new reader with atomic reference counting
+    ///
+    /// # Memory Ordering
+    /// Uses `Ordering::AcqRel` to synchronize with other atomic operations:
+    /// - Acquire: See previous writes to the buffer
+    /// - Release: Make buffer writes visible to others
+    pub fn acquire_reader(&self) {
+        self.readers.fetch_add(1, Ordering::AcqRel);
+    }
 
-impl FifoNode {
-    /// Create a new FIFO node.
-    pub fn new(ino: u64) -> Self {
-        Self {
-            ino,
-            fifo: Fifo::new(),
-        }
+    /// Unregisters a reader and checks for underflow
+    pub fn release_reader(&self) {
+        let cnt_before = self.readers.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(cnt_before != 0)
+    }
+
+    /// Returns current number of active writers
+    pub fn writers(&self) -> usize {
+        self.writers.load(Ordering::Acquire)
+    }
+
+    /// Registers a new writer with atomic reference counting
+    pub fn acquire_writer(&self) {
+        self.writers.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Unregisters a writer and checks for underflow
+    pub fn release_writer(&self) {
+        let cnt_before = self.writers.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(cnt_before != 0)
+    }
+
+    /// Checks readable status and peer existence for readers
+    pub fn reader_poll(&self) -> VfsResult<PollState> {
+        let buffer = self.buffer.lock();
+        Ok(PollState {
+            readable: !buffer.is_empty(),
+            writable: false,
+            pollhup: self.writers() == 0,
+        })
+    }
+
+    /// Checks writable status and peer existence for writers
+    pub fn writer_poll(&self) -> VfsResult<PollState> {
+        let buffer = self.buffer.lock();
+        Ok(PollState {
+            readable: false,
+            writable: !buffer.is_full(),
+            pollhup: self.readers() == 0,
+        })
     }
 }
 
 impl VfsNodeOps for FifoNode {
     fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
-        Ok(VfsNodeAttr::new_fifo(self.ino))
+        Ok(self.attr)
     }
 
     // for fifo, offset is useless and ignored
     fn read_at(&self, _offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
-        Ok(self.fifo.read(buf).unwrap_or(0))
+        let mut buffer = self.buffer.lock();
+        if buffer.is_empty() {
+            return Err(AxError::WouldBlock);
+        }
+        Ok(buffer.read(buf))
     }
 
     // for fifo, offset is useless and ignored
     fn write_at(&self, _offset: u64, buf: &[u8]) -> VfsResult<usize> {
-        Ok(self.fifo.write(buf).unwrap_or(0))
-    }
-
-    // check if there are any readers
-    fn fifo_has_readers(&self) -> bool {
-        self.fifo.readers.load(Ordering::SeqCst) > 0
-    }
-
-    // open a fifo node
-    fn open_fifo(
-        &self,
-        read: bool,
-        write: bool,
-        non_blocking: bool,
-    ) -> VfsResult<Option<VfsNodeRef>> {
-        debug!(
-            "open a fifo node: read={}, write={}, non_blocking={}",
-            read, write, non_blocking
-        );
-        if read {
-            self.fifo.readers.fetch_add(1, Ordering::SeqCst);
-            if !non_blocking {
-                while self.fifo.writers.load(Ordering::SeqCst) == 0 {
-                    sched_yield();
-                }
-            }
+        let mut buffer = self.buffer.lock();
+        if buffer.is_full() {
+            return Err(AxError::WouldBlock);
         }
-        if write {
-            self.fifo.writers.fetch_add(1, Ordering::SeqCst);
-            if !non_blocking {
-                while self.fifo.readers.load(Ordering::SeqCst) == 0 {
-                    sched_yield();
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    // release a fifo node
-    fn release_fifo(&self, read: bool, write: bool) -> VfsResult {
-        debug!("release a fifo node");
-        if read {
-            self.fifo.readers.fetch_sub(1, Ordering::SeqCst);
-        }
-        if write {
-            self.fifo.writers.fetch_sub(1, Ordering::SeqCst);
-        }
-        Ok(())
+        Ok(buffer.write(buf))
     }
 
     // fifo does not support truncate
@@ -153,17 +151,4 @@ impl VfsNodeOps for FifoNode {
     }
 
     impl_vfs_non_dir_default! {}
-}
-
-// here, we cannot use ruxtask for possible cyclic package dependency.
-// so we use the following code to simulate the behavior of ruxtask::sched_yield.
-// actually, sched_yield() is similar to sys_sched_yield() in ruxos_posix_api,
-// the only difference is that we deleted the `#[cfg(feature = "multitask")]` attribute.
-fn sched_yield() {
-    #[cfg(not(feature = "multitask"))]
-    if cfg!(feature = "irq") {
-        ruxhal::arch::wait_for_irqs();
-    } else {
-        core::hint::spin_loop();
-    }
 }

--- a/crates/axfs_vfs/src/lib.rs
+++ b/crates/axfs_vfs/src/lib.rs
@@ -53,6 +53,8 @@ mod macros;
 mod path;
 mod structs;
 
+use core::any::Any;
+
 use alloc::sync::Arc;
 use axerrno::{ax_err, AxError, AxResult};
 
@@ -99,16 +101,6 @@ pub trait VfsNodeOps: Send + Sync {
     /// Do something when the node is opened.
     /// For example, open some special nodes like `/dev/ptmx` should return a new node named `PtyMaster`
     fn open(&self) -> VfsResult<Option<VfsNodeRef>> {
-        Ok(None)
-    }
-
-    /// Do something when the node is opened as a fifo.
-    fn open_fifo(
-        &self,
-        _read: bool,
-        _write: bool,
-        _non_blocking: bool,
-    ) -> VfsResult<Option<VfsNodeRef>> {
         Ok(None)
     }
 
@@ -240,6 +232,11 @@ pub trait VfsNodeOps: Send + Sync {
         unimplemented!()
     }
 
+    /// Provides type-erased access to the underlying `Arc` for downcasting.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        unimplemented!()
+    }
+
     /// Create a new node with given `path` in the directory, recursively.
     ///
     /// Default implementation `create`s all prefix sub-paths sequentially,
@@ -261,11 +258,6 @@ pub trait VfsNodeOps: Send + Sync {
         self.create(path, ty)?;
 
         Ok(())
-    }
-
-    /// if the node is a fifo, check if there are readers
-    fn fifo_has_readers(&self) -> bool {
-        false
     }
 }
 

--- a/crates/axfs_vfs/src/macros.rs
+++ b/crates/axfs_vfs/src/macros.rs
@@ -34,6 +34,13 @@ macro_rules! impl_vfs_dir_default {
         fn as_any(&self) -> &dyn core::any::Any {
             self
         }
+
+        #[inline]
+        fn as_any_arc(
+            self: $crate::__priv::Arc<Self>,
+        ) -> $crate::__priv::Arc<dyn core::any::Any + Send + Sync> {
+            self
+        }
     };
 }
 
@@ -85,6 +92,13 @@ macro_rules! impl_vfs_non_dir_default {
 
         #[inline]
         fn as_any(&self) -> &dyn core::any::Any {
+            self
+        }
+
+        #[inline]
+        fn as_any_arc(
+            self: $crate::__priv::Arc<Self>,
+        ) -> $crate::__priv::Arc<dyn core::any::Any + Send + Sync> {
             self
         }
     };

--- a/modules/ruxfdtable/src/lib.rs
+++ b/modules/ruxfdtable/src/lib.rs
@@ -353,13 +353,9 @@ pub trait FileLike: Send + Sync {
     /// Only File Status Flags can be changed once a file is opened. Other flags will be ignored.
     fn set_flags(&self, _flags: OpenFlags) -> LinuxResult;
 
-    /// Get flags.
-    ///
-    /// Actually only File Status Flags is used. File Access Modes and Creation Flags needn't store.
-    /// The reason is that this function will be called by `sys_fcntl`, which only need to return status flag.
-    fn flags(&self) -> OpenFlags {
-        OpenFlags::empty()
-    }
+    /// Return File Access Modes and File Status Flags. Creation Flags needn't store.
+    /// `sys_fcntl` command `F_GETFL` will need both kinds
+    fn flags(&self) -> OpenFlags;
 
     /// Handles ioctl commands for the device.
     fn ioctl(&self, _cmd: usize, _arg: usize) -> LinuxResult<usize> {
@@ -468,12 +464,7 @@ impl OpenFlags {
 
     /// Return the file access mode and the file status flags. Used in `sys_fcntl` with `F_GETFL` mode
     pub fn getfl(&self) -> Self {
-        *self & Self::O_ACCMODE & !Self::CREATION_FLAGS
-    }
-
-    /// Return the mode for `sys_open` syscall, whether it is blocking or non-blocking
-    pub fn is_non_blocking(&self) -> bool {
-        self.contains(Self::O_NONBLOCK)
+        *self & !Self::CREATION_FLAGS
     }
 }
 

--- a/modules/ruxfs/src/api/mod.rs
+++ b/modules/ruxfs/src/api/mod.rs
@@ -17,7 +17,6 @@ pub use super::{
 };
 use alloc::{string::String, vec::Vec};
 use axerrno::ax_err;
-use axerrno::AxError;
 use axfs_vfs::VfsError;
 use axio::{self as io, prelude::*, Error, Result};
 /// Opens a regular file at given path. Fails if path points to a directory.
@@ -85,32 +84,6 @@ pub fn write<C: AsRef<[u8]>>(path: &AbsPath, contents: C) -> io::Result<()> {
         OpenFlags::O_WRONLY | OpenFlags::O_CREAT | OpenFlags::O_TRUNC,
     )?
     .write_all(contents.as_ref())
-}
-
-/// Creates a new file at the provided path.
-/// We only support creating regular files and FIFOs.
-///
-/// TODO: support permissions for sys_mknod and create_node.
-pub fn create_node(
-    path: &AbsPath,
-    file_type: FileType,
-    // perm: Permissions,
-) -> io::Result<()> {
-    match file_type {
-        FileType::File => {
-            fops::create_file(&path)?;
-            Ok(())
-        }
-        FileType::Fifo => {
-            if path.starts_with("/tmp/") {
-                fops::create_fifo(&path)?;
-                Ok(())
-            } else {
-                return Err(AxError::Unsupported);
-            }
-        }
-        _ => return Err(AxError::Unsupported),
-    }
 }
 
 /// Creates a new, empty directory at the provided path.

--- a/modules/ruxfs/src/fifo.rs
+++ b/modules/ruxfs/src/fifo.rs
@@ -1,0 +1,244 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+//! Named pipe (FIFO) implementation for VFS
+use alloc::sync::Arc;
+use axerrno::{AxError, LinuxError, LinuxResult};
+use axfs_ramfs::FifoNode;
+use axfs_vfs::VfsNodeOps;
+use axio::PollState;
+use crate_interface::call_interface;
+use ruxfdtable::{FileLike, OpenFlags, RuxStat};
+use spin::rwlock::RwLock;
+
+use crate::AbsPath;
+
+/// Reader endpoint for both FIFO (named pipe) and Pipe communication
+pub struct FifoReader {
+    /// Absolute path in virtual filesystem
+    path: AbsPath<'static>,
+    /// Shared FIFO buffer
+    node: Arc<FifoNode>,
+    /// Current open flags, e.g. `O_NONBLOCK`
+    flags: RwLock<OpenFlags>,
+}
+
+impl FifoReader {
+    /// Opening a FIFO for reading data (using the open() function with the O_RDONLY flag)
+    /// block until another process opens the FIFO for writing data (using the open() function with the O_WRONLY flag).
+    pub fn new(path: AbsPath<'static>, node: Arc<FifoNode>, flags: OpenFlags) -> Self {
+        node.acquire_reader();
+        while node.writers() == 0 {
+            // PERF: use wait and wakeup instead of yield now
+            call_interface!(SchedYieldIf::yield_now);
+            if flags.contains(OpenFlags::O_NONBLOCK) {
+                // Opening a FIFO for reading is safe when the other end has no writer, as read operations will return no data.
+                break;
+            }
+        }
+        Self {
+            path,
+            node,
+            flags: RwLock::new(flags),
+        }
+    }
+}
+
+impl Drop for FifoReader {
+    /// Decrements reader count and triggers wakeups
+    fn drop(&mut self) {
+        call_interface!(SchedYieldIf::yield_now);
+        self.node.release_reader()
+    }
+}
+
+impl FileLike for FifoReader {
+    fn path(&self) -> AbsPath {
+        self.path.to_owned()
+    }
+
+    /// Reads data from FIFO with blocking behavior
+    ///
+    /// - Returns 0 when all writers closed and buffer empty
+    /// - EAGAIN if non-blocking and no data available
+    fn read(&self, buf: &mut [u8]) -> LinuxResult<usize> {
+        loop {
+            match self.node.read_at(0, buf) {
+                Ok(len) => return Ok(len),
+                Err(AxError::WouldBlock) => {
+                    // writer end closed and there is no data to read
+                    if self.node.writers() == 0 {
+                        return Ok(0);
+                    }
+                    if self.flags.read().contains(OpenFlags::O_NONBLOCK) {
+                        return Err(LinuxError::EAGAIN);
+                    }
+                    crate_interface::call_interface!(SchedYieldIf::yield_now);
+                }
+                err => return err.map_err(LinuxError::from),
+            }
+        }
+    }
+
+    /// fd is not open for writing. In this case should return `LinuxError::EBADF`
+    /// See `<https://man7.org/linux/man-pages/man2/write.2.html>`
+    fn write(&self, _buf: &[u8]) -> LinuxResult<usize> {
+        Err(LinuxError::EBADF)
+    }
+
+    fn flush(&self) -> LinuxResult {
+        Ok(())
+    }
+
+    fn stat(&self) -> LinuxResult<RuxStat> {
+        Ok(RuxStat::from(self.node.get_attr()?))
+    }
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn core::any::Any + Send + Sync> {
+        self
+    }
+
+    fn poll(&self) -> LinuxResult<PollState> {
+        self.node.reader_poll().map_err(LinuxError::from)
+    }
+
+    fn set_flags(&self, flags: OpenFlags) -> LinuxResult {
+        *self.flags.write() = flags;
+        Ok(())
+    }
+
+    fn flags(&self) -> OpenFlags {
+        *self.flags.read() | OpenFlags::O_RDONLY
+    }
+}
+
+/// Writer endpoint for both FIFO (named pipe) and Pipe communication
+pub struct FifoWriter {
+    path: AbsPath<'static>,
+    node: Arc<FifoNode>,
+    flags: RwLock<OpenFlags>,
+}
+
+impl FifoWriter {
+    /// Creates new writer endpoint with POSIX error handling
+    ///
+    /// # Error Conditions
+    /// - `ENXIO` when non-blocking and no readers available
+    /// - Blocks indefinitely without O_NONBLOCK until reader appears
+    pub fn new(path: AbsPath<'static>, node: Arc<FifoNode>, flags: OpenFlags) -> LinuxResult<Self> {
+        node.acquire_writer();
+        while node.readers() == 0 {
+            // PERF: use wait and wakeup instead of yield now
+            call_interface!(SchedYieldIf::yield_now);
+            if flags.contains(OpenFlags::O_NONBLOCK) {
+                // opening a FIFO with ​**O_WRONLY** and ​**O_NONBLOCK** flags if no process has the FIFO open for reading will cause err
+                return Err(LinuxError::ENXIO);
+            }
+        }
+        Ok(Self {
+            path,
+            node,
+            flags: RwLock::new(flags),
+        })
+    }
+}
+
+impl Drop for FifoWriter {
+    fn drop(&mut self) {
+        call_interface!(SchedYieldIf::yield_now);
+        self.node.release_writer();
+    }
+}
+
+impl FileLike for FifoWriter {
+    fn path(&self) -> AbsPath {
+        self.path.to_owned()
+    }
+
+    /// fd is not open for reading. In this case should return `LinuxError::EBADF`
+    /// See `<https://man7.org/linux/man-pages/man2/read.2.html>`
+    fn read(&self, _buf: &mut [u8]) -> LinuxResult<usize> {
+        Err(LinuxError::EBADF)
+    }
+
+    /// Writes data with backpressure management
+    ///
+    /// # Error Conditions
+    /// - `EPIPE` when all readers closed
+    /// - `EAGAIN` if non-blocking and buffer full
+    fn write(&self, buf: &[u8]) -> LinuxResult<usize> {
+        // TODO: when FifoNode has no reader when writing, send `SIGPIPE` signal
+        if self.node.readers() == 0 {
+            return Err(LinuxError::EPIPE);
+        }
+        loop {
+            match self.node.write_at(0, buf) {
+                Ok(len) => return Ok(len),
+                Err(AxError::WouldBlock) => {
+                    if self.flags.read().contains(OpenFlags::O_NONBLOCK) {
+                        return Err(LinuxError::EAGAIN);
+                    }
+                    crate_interface::call_interface!(SchedYieldIf::yield_now);
+                }
+                Err(_) => todo!(),
+            }
+        }
+    }
+
+    fn flush(&self) -> LinuxResult {
+        Ok(())
+    }
+
+    fn stat(&self) -> LinuxResult<RuxStat> {
+        Ok(RuxStat::from(self.node.get_attr()?))
+    }
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn core::any::Any + Send + Sync> {
+        self
+    }
+
+    fn poll(&self) -> LinuxResult<PollState> {
+        self.node.writer_poll().map_err(LinuxError::from)
+    }
+
+    fn set_flags(&self, flags: OpenFlags) -> LinuxResult {
+        *self.flags.write() = flags;
+        Ok(())
+    }
+
+    fn flags(&self) -> OpenFlags {
+        *self.flags.read() | OpenFlags::O_WRONLY
+    }
+}
+
+/// Creates connected pipe pair with shared buffer
+///
+/// If no endpoint is closed, readers count and writers count must always be 1 in `Arc<FifoNode>`,
+/// because Arc clone won't increase the count
+pub fn new_pipe_pair(flags: OpenFlags) -> (Arc<FifoReader>, Arc<FifoWriter>) {
+    let (reader_node, writer_node) = FifoNode::new_pair();
+    let reader = Arc::new(FifoReader {
+        path: AbsPath::new(""),
+        node: reader_node,
+        flags: RwLock::new(flags),
+    });
+    let writer = Arc::new(FifoWriter {
+        path: AbsPath::new(""),
+        node: writer_node,
+        flags: RwLock::new(flags),
+    });
+    (reader, writer)
+}
+
+#[crate_interface::def_interface]
+/// task yield interface
+pub trait SchedYieldIf {
+    /// Yields CPU using appropriate scheduling strategy
+    fn yield_now();
+}

--- a/modules/ruxfs/src/file.rs
+++ b/modules/ruxfs/src/file.rs
@@ -186,6 +186,10 @@ impl FileLike for File {
         *self.flags.write() = flags;
         Ok(())
     }
+
+    fn flags(&self) -> OpenFlags {
+        *self.flags.read()
+    }
 }
 
 impl Read for File {

--- a/modules/ruxfs/src/fops.rs
+++ b/modules/ruxfs/src/fops.rs
@@ -14,13 +14,15 @@
 //!
 //! The interface is designed with low coupling to avoid repetitive error handling.
 use alloc::{sync::Arc, vec::Vec};
-use axerrno::{AxError, AxResult};
+use axerrno::{AxError, AxResult, LinuxResult};
+use axfs_ramfs::FifoNode;
 use axfs_vfs::{AbsPath, RelPath, VfsNodeOps, VfsNodeRef, VfsNodeType};
 use capability::Cap;
 use ruxfdtable::{FileLike, OpenFlags};
 
 use crate::{
     directory::Directory,
+    fifo::{FifoReader, FifoWriter},
     file::File,
     root::{MountPoint, RootDirectory},
     FileAttr,
@@ -109,13 +111,6 @@ pub(crate) fn open_abspath(path: &AbsPath, flags: OpenFlags) -> AxResult<VfsNode
     if !Cap::from(attr.perm()).contains(Cap::from(flags)) {
         return Err(AxError::PermissionDenied);
     }
-    if node.get_attr()?.is_fifo() {
-        if let Some(new_node) =
-            node.open_fifo(flags.readable(), flags.writable(), flags.is_non_blocking())?
-        {
-            return Ok(new_node);
-        }
-    }
     if let Some(new_node) = node.open()? {
         return Ok(new_node);
     }
@@ -123,14 +118,20 @@ pub(crate) fn open_abspath(path: &AbsPath, flags: OpenFlags) -> AxResult<VfsNode
 }
 
 /// Opens a file-like object (file or directory) at given path with flags.
-pub fn open_file_like(path: &AbsPath, flags: OpenFlags) -> AxResult<Arc<dyn FileLike>> {
+pub fn open_file_like(path: &AbsPath, flags: OpenFlags) -> LinuxResult<Arc<dyn FileLike>> {
     let node = open_abspath(path, flags)?;
-    if node.get_attr()?.is_dir() {
-        Ok(Arc::new(Directory::new(path.to_owned(), node, flags)))
-    } else if node.get_attr()?.is_fifo() {
-        Ok(Arc::new(File::new(path.to_owned(), node, flags)))
-    } else {
-        Ok(Arc::new(File::new(path.to_owned(), node, flags)))
+    match node.get_attr()?.file_type() {
+        VfsNodeType::Dir => Ok(Arc::new(Directory::new(path.to_owned(), node, flags))),
+        VfsNodeType::File => Ok(Arc::new(File::new(path.to_owned(), node, flags))),
+        VfsNodeType::Fifo => {
+            let node = Arc::downcast::<FifoNode>(node.as_any_arc()).unwrap();
+            if flags.contains(OpenFlags::O_WRONLY) {
+                Ok(Arc::new(FifoWriter::new(path.to_owned(), node, flags)?))
+            } else {
+                Ok(Arc::new(FifoReader::new(path.to_owned(), node, flags)))
+            }
+        }
+        _ => Ok(Arc::new(File::new(path.to_owned(), node, flags))),
     }
 }
 

--- a/modules/ruxfs/src/lib.rs
+++ b/modules/ruxfs/src/lib.rs
@@ -43,6 +43,7 @@ pub mod api;
 #[cfg(feature = "blkfs")]
 pub mod dev;
 mod directory;
+pub mod fifo;
 mod file;
 pub mod fops;
 pub mod root;

--- a/modules/ruxruntime/tests/test_ramfs.rs
+++ b/modules/ruxruntime/tests/test_ramfs.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 use axfs_ramfs::RamFileSystem;
 use axfs_vfs::VfsOps;
 use axio::{Result, Write};
-use driver_block::ramdisk::RamDisk;
-use ruxdriver::AxDeviceContainer;
 use ruxfs::{api as fs, MyFileSystemIf};
 use test_common::open_file_create_new;
 struct MyFileSystemIfImpl;

--- a/modules/ruxtask/src/signal.rs
+++ b/modules/ruxtask/src/signal.rs
@@ -54,8 +54,8 @@ pub struct Signal {
     timer_interval: [Duration; 3],
 }
 
-unsafe extern "C" fn default_handler(signum: c_int) {
-    panic!("default_handler, signum: {}", signum);
+unsafe extern "C" fn default_handler(_signum: c_int) {
+    // panic!("default_handler, signum: {}", signum);
 }
 
 #[cfg(feature = "signal")]


### PR DESCRIPTION
- Refactor FIFO implementation to retain original VFS interfaces while adding `as_any_arc()` method to recover erased types from Arc<dyn Trait>
- Reimplement pipes by reusing FIFO code, enabling batch reads from ring buffers instead of byte-by-byte access for better I/O performance
- Consolidate sys_pipe into sys_pipe2 with default flags (0).
- Fix sys_fcntl flags preservation by properly storing File Access Mode bits (previously overwritten during modification)